### PR TITLE
new domain

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
   openGraph: {
     images: [
       {
-        url: 'https://neon-demos-branching.vercel.app/og.png',
+        url: 'https://neon-branching-demo.vercel.app/og.png',
       },
     ],
   },


### PR DESCRIPTION
i re-deployed the project to https://neon-demo-branching.vercel.app/ as the older domain seems to be taken over after this demo got taken down from Vercel due to the recent env affect across all neon repos